### PR TITLE
Logic: Add alias to prefix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -47,11 +47,13 @@ public class ArgumentTokenizer {
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
         List<PrefixPosition> positions = new ArrayList<>();
 
-        int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
-        while (prefixPosition != -1) {
-            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
-            positions.add(extendedPrefix);
-            prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+        for (String alias: prefix.getAliases()) {
+            int prefixPosition = findPrefixPosition(argsString, alias, 0);
+            while (prefixPosition != -1) {
+                PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
+                positions.add(extendedPrefix);
+                prefixPosition = findPrefixPosition(argsString, alias, prefixPosition);
+            }
         }
 
         return positions;
@@ -118,10 +120,15 @@ public class ArgumentTokenizer {
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
-        String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
+        for (String alias: prefix.getAliases()) {
+            if (argsString.startsWith(alias, currentPrefixPosition.getStartPosition())) {
+                int valueStartPos = currentPrefixPosition.getStartPosition() + alias.length();
+                String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
+                return value.trim();
+            }
+        }
 
-        return value.trim();
+        return "";
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,14 +6,14 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("name/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("address/");
-    public static final Prefix PREFIX_TAG = new Prefix("tag/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("email/");
-    public static final Prefix PREFIX_PHONE = new Prefix("phone/");
-    public static final Prefix PREFIX_SLACK = new Prefix("slack/");
-    public static final Prefix PREFIX_TELEGRAM = new Prefix("telegram/");
-    public static final Prefix PREFIX_ROLE = new Prefix("role/");
-    public static final Prefix PREFIX_TIMEZONE = new Prefix("timezone/");
+    public static final Prefix PREFIX_NAME = new Prefix("name/", "n/");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("address/", "a/");
+    public static final Prefix PREFIX_TAG = new Prefix("tag/", "t/");
+    public static final Prefix PREFIX_EMAIL = new Prefix("email/", "@/");
+    public static final Prefix PREFIX_PHONE = new Prefix("phone/", "+/");
+    public static final Prefix PREFIX_SLACK = new Prefix("slack/", "sk/");
+    public static final Prefix PREFIX_TELEGRAM = new Prefix("telegram/", "tele/");
+    public static final Prefix PREFIX_ROLE = new Prefix("role/", "r/");
+    public static final Prefix PREFIX_TIMEZONE = new Prefix("timezone/", "tz/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -1,27 +1,48 @@
 package seedu.address.logic.parser;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. 't/' in 'add James t/ friend'.
+ * A prefix can contain multiple aliases such as 'name/', 'n/', '-n'. They all
+ * indicate the same prefix.
  */
 public class Prefix {
-    private final String prefix;
+    private final ArrayList<String> aliases;
 
-    public Prefix(String prefix) {
-        this.prefix = prefix;
+    /**
+     * Construct a Prefix instance with a list of aliases.
+     *
+     * @param aliases a list of aliases to the prefix
+     */
+    public Prefix(String... aliases) {
+        assert aliases.length > 0 : "Must have at least one valid prefix";
+        this.aliases = new ArrayList<>(Arrays.asList(aliases));
     }
 
-    public String getPrefix() {
-        return prefix;
+    /**
+     * Returns the primary alias of the prefix, which is the first element in aliases array.
+     */
+    public String getAlias() {
+        return aliases.get(0);
+    }
+
+    /**
+     * Returns all aliases to this prefix.
+     */
+    public ArrayList<String> getAliases() {
+        return aliases;
     }
 
     public String toString() {
-        return getPrefix();
+        return getAlias();
     }
 
     @Override
     public int hashCode() {
-        return prefix == null ? 0 : prefix.hashCode();
+        return aliases == null ? 0 : aliases.hashCode();
     }
 
     @Override
@@ -34,6 +55,6 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix());
+        return otherPrefix.getAliases().equals(getAliases());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -13,6 +13,8 @@ public class ArgumentTokenizerTest {
     private final Prefix pSlash = new Prefix("p/");
     private final Prefix dashT = new Prefix("-t");
     private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix namePrefix = new Prefix("name/", "n/", "-n");
+    private final Prefix rolePrefix = new Prefix("role/", "r/", "-r");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -134,6 +136,24 @@ public class ArgumentTokenizerTest {
         assertArgumentAbsent(argMultimap, pSlash);
         assertArgumentPresent(argMultimap, dashT, "not joined^Qjoined");
         assertArgumentAbsent(argMultimap, hatQ);
+    }
+
+    @Test
+    public void tokenize_multipleAliases() {
+        String argsString = "SomePreambleString name/test1 n/test2 -n test3";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, namePrefix);
+        assertPreamblePresent(argMultimap, "SomePreambleString");
+        assertArgumentPresent(argMultimap, namePrefix, "test1", "test2", "test3");
+    }
+
+    @Test
+    public void tokenize_multipleArgumentsWithmultipleAliases() {
+        String argsString = "SomePreambleString -t not -t test name/test1 role/not -r test n/test2 -n test3 name/test4";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, dashT, rolePrefix, namePrefix);
+        assertPreamblePresent(argMultimap, "SomePreambleString");
+        assertArgumentPresent(argMultimap, dashT, "not", "test");
+        assertArgumentPresent(argMultimap, dashT, "not", "test");
+        assertArgumentPresent(argMultimap, namePrefix, "test1", "test2", "test3", "test4");
     }
 
     @Test


### PR DESCRIPTION
This PR allows user to pass argument with multiple aliases. For example, `name/`, `n/` refers to the same prefix.